### PR TITLE
Fix reported version number

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
@@ -19,6 +19,7 @@ requirements:
     - pip
     - python >=3.6
     - setuptools >=42
+    - setuptools_scm >=3.4
     - wheel
   run:
     - python >=3.6


### PR DESCRIPTION
`asf_search` when installed via conda-forge reports a version number of `0.0.0`:
```shell
$ conda create -n foo python asf_search
$ conda activate foo
$ python -c 'import asf_search; print(asf_search.__version__)'
0.0.0
```

However a `pip` install works just fine:
```shell
$ conda create -n bar python
$ conda activate bar
$ python -m pip install asf_search
$ python -c 'import asf_search; print(asf_search.__version__)'
5.0.1
```

This is because conda uses the source tarball to install the package, but is missing the `setuptools_scm` build dependency which handles the version info:
https://github.com/asfadmin/Discovery-asf_search/blob/master/pyproject.toml#L5

This adds the missing build dependency and bumps the build number for conda-forge fixing this issue. 